### PR TITLE
next-themes, improved navbar theme controls

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "jwt-decode": "3.1.2",
     "lucide-react": "^0.216.0",
     "next": "13.4.2",
+    "next-themes": "^0.2.1",
     "postcss": "8.4.23",
     "prettier": "^2.8.8",
     "prettier-plugin-tailwindcss": "^0.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,6 +49,9 @@ dependencies:
   next:
     specifier: 13.4.2
     version: 13.4.2(react-dom@18.2.0)(react@18.2.0)
+  next-themes:
+    specifier: ^0.2.1
+    version: 0.2.1(next@13.4.2)(react-dom@18.2.0)(react@18.2.0)
   postcss:
     specifier: 8.4.23
     version: 8.4.23
@@ -2602,6 +2605,18 @@ packages:
 
   /natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+    dev: false
+
+  /next-themes@0.2.1(next@13.4.2)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-B+AKNfYNIzh0vqQQKqQItTS8evEouKD7H5Hj3kmuPERwddR2TxvDSFZuTj6T7Jfn1oyeUyJMydPl1Bkxkh0W7A==}
+    peerDependencies:
+      next: '*'
+      react: '*'
+      react-dom: '*'
+    dependencies:
+      next: 13.4.2(react-dom@18.2.0)(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
     dev: false
 
   /next@13.4.2(react-dom@18.2.0)(react@18.2.0):

--- a/src/app/(app)/page.tsx
+++ b/src/app/(app)/page.tsx
@@ -19,6 +19,8 @@ export default function Page() {
               width={1200}
               height={1000}
               alt="hero-dashboard"
+              placeholder='blur'
+              blurDataURL='/assets/screenshots/dashboard-d.jpg'
               priority={true}
             />
           </div>
@@ -51,7 +53,6 @@ export default function Page() {
               width={1200}
               height={1000}
               alt="hero-dashboard"
-              priority={true}
             />
           </div>
           <div className="min-w-[50%] text-right">
@@ -74,7 +75,6 @@ export default function Page() {
               width={1200}
               height={1000}
               alt="hero-dashboard"
-              priority={true}
             />
           </div>
           <div className="min-w-[50%]">
@@ -96,7 +96,6 @@ export default function Page() {
               width={1200}
               height={1000}
               alt="hero-dashboard"
-              priority={true}
             />
           </div>
           <div className="min-w-[50%] text-right">
@@ -119,7 +118,6 @@ export default function Page() {
               width={1200}
               height={1000}
               alt="hero-dashboard"
-              priority={true}
             />
           </div>
           <div className="min-w-[50%]">

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -13,6 +13,7 @@ import NavBar from '~/components/Navbar'
 import Footer from '~/components/Footer'
 
 import '~/globals.css'
+import { Providers } from './providers'
 
 interface Props {
   children: React.ReactNode
@@ -22,12 +23,14 @@ export default async function RootLayout(props: Props) {
   const user = await getAuthUser()
 
   return (
-    <html lang="en" data-theme="light">
+    <html lang="en" data-theme="light" suppressHydrationWarning>
       <body className={inter.className}>
-        <NavBar user={user} />
-        {props.children}
-        <Footer user={user} />
-        {/* <Analytics /> */}
+        <Providers>
+          <NavBar user={user} />
+          {props.children}
+          <Footer user={user} />
+          {/* <Analytics /> */}
+        </Providers>
       </body>
     </html>
   )

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -1,0 +1,7 @@
+'use client'
+
+import { ThemeProvider } from 'next-themes'
+
+export function Providers({ children }) {
+    return <ThemeProvider>{children}</ThemeProvider>
+}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -14,11 +14,13 @@ export default function Footer({ user }: Props) {
       <div className="footer mx-auto max-w-[1400px]">
         <div>
           <Image
-            priority={true}
             src="/assets/brand/pepiti-logo.svg"
+            style={{ width: 'auto', height: 'auto' }}
             width={120}
             height={120}
             alt="pepiti_brand"
+            placeholder='blur'
+            blurDataURL='/assets/brand/pepiti-logo.svg'
           />
           <p>
             Copyright © {date.getFullYear()} Pepiti

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,5 +1,11 @@
 'use client'
 
+import React from "react"
+import { useTheme } from "next-themes"
+import { usePathname } from "next/navigation"
+import Image from "next/image"
+import Link from "next/link"
+import DonationBanner from "~/app/(app)/dashboard/components/DonationBanner"
 import {
   FlagIcon,
   LayoutDashboardIcon,
@@ -10,56 +16,43 @@ import {
   SunIcon,
   TrophyIcon,
   UserIcon,
-} from 'lucide-react'
-import { useTheme } from 'next-themes'
-import Image from 'next/image'
-import Link from 'next/link'
-import { usePathname } from 'next/navigation'
-import React, { useEffect, useState } from 'react'
-import DonationBanner from '~/app/(app)/dashboard/components/DonationBanner'
+} from "lucide-react"
 
 interface Props {
   user: User
 }
 
 function NavBar({ user }: Props) {
-  const pathname = usePathname()
-  const atDashboard = pathname === '/dashboard'
   const { theme, setTheme } = useTheme()
+  const pathname = usePathname()
 
-  const handleThemeChange = () => {
-    if (theme === 'light') {
-      setTheme('dark')
-    } else {
-      setTheme('light')
-    }
-  }
+  const handleThemeChange = () => (theme === "light" ? setTheme("dark") : setTheme("light"))
 
   const secondaryLinks = [
     {
       href: `/profile/${user.guid}`,
-      label: 'Profile',
+      label: "Profile",
       icon: <UserIcon />,
       public: false,
       admin: false,
     },
     {
-      href: '/report',
-      label: 'Report Rider',
+      href: "/report",
+      label: "Report Rider",
       icon: <FlagIcon />,
       public: true,
       admin: false,
     },
     {
-      href: '/blacklists',
-      label: 'Blacklists',
+      href: "/blacklists",
+      label: "Blacklists",
       icon: <ScrollTextIcon />,
       public: true,
       admin: false,
     },
     {
-      href: '/admin',
-      label: 'Admin Portal',
+      href: "/admin",
+      label: "Admin Portal",
       icon: <ShieldAlertIcon />,
       public: false,
       admin: true,
@@ -68,9 +61,10 @@ function NavBar({ user }: Props) {
       label: (
         <div
           onClick={handleThemeChange}
-          className="flex w-full items-center justify-between max-md:text-[16px] lg:gap-2">
-          <div className="max-md:text-[16px]">{theme === 'light' ? 'Dark Mode' : 'Light Mode'}</div>
-          <div>{theme === 'light' ? <MoonIcon /> : <SunIcon />}</div>
+          className="flex w-full items-center justify-between max-md:text-[16px] lg:gap-2"
+        >
+          <div className="max-md:text-[16px]">{theme === "light" ? "Dark Mode" : "Light Mode"}</div>
+          <div>{theme === "light" ? <MoonIcon /> : <SunIcon />}</div>
         </div>
       ),
       public: true,
@@ -82,9 +76,11 @@ function NavBar({ user }: Props) {
           href="https://pepiti.com/stats/api/v0/steam_login"
           target="_blank"
           referrerPolicy="origin"
-          className={`btn-ghost btn mt-[2px] h-full w-full border-none text-error ${user.guid ? 'btn-error' : ''
-            }`}>
-          {user.guid ? 'Change User' : 'Sign In'}
+          className={`btn-ghost btn mt-[2px] h-full w-full border-none text-error ${
+            user.guid ? "btn-error" : ""
+          }`}
+        >
+          {user.guid ? "Change User" : "Sign In"}
         </Link>
       ),
       public: true,
@@ -113,18 +109,18 @@ function NavBar({ user }: Props) {
 
   const primaryLinks = [
     {
-      href: '/dashboard',
-      label: 'Dashboard',
+      href: "/dashboard",
+      label: "Dashboard",
       icon: <LayoutDashboardIcon />,
     },
     {
-      href: '/races',
-      label: 'Races',
+      href: "/races",
+      label: "Races",
       icon: <ScrollTextIcon />,
     },
     {
-      href: '/leagues',
-      label: 'Leagues',
+      href: "/leagues",
+      label: "Leagues",
       icon: <TrophyIcon />,
     },
   ]
@@ -134,7 +130,8 @@ function NavBar({ user }: Props) {
       <Link
         key={idx}
         href={link.href}
-        className="btn-ghost btn flex justify-between border-none font-normal normal-case hover:bg-secondary hover:text-white lg:mr-2 lg:font-semibold">
+        className="btn-ghost btn flex justify-between border-none font-normal normal-case hover:bg-secondary hover:text-white lg:mr-2 lg:font-semibold"
+      >
         <div className="flex w-full items-center justify-between max-md:text-[16px] lg:gap-2">
           {link.label}
           {link.icon}
@@ -150,14 +147,15 @@ function NavBar({ user }: Props) {
           <div className="navbar-start">
             <Link
               href="/dashboard"
-              className="btn-ghost btn border-none hover:bg-secondary hover:text-white relative w-14">
+              className="btn-ghost btn relative w-14 border-none hover:bg-secondary hover:text-white"
+            >
               <Image
                 priority={true}
                 src="/assets/brand/pepiti-logo.svg"
                 fill
                 alt="pepiti_brand"
-                placeholder='blur'
-                blurDataURL='/assets/brand/pepiti-logo.svg'
+                placeholder="blur"
+                blurDataURL="/assets/brand/pepiti-logo.svg"
               />
             </Link>
           </div>
@@ -170,12 +168,14 @@ function NavBar({ user }: Props) {
             <div className="dropdown-end dropdown">
               <label
                 tabIndex={0}
-                className="btn-ghost rounded-btn btn border-none hover:bg-secondary hover:text-white">
+                className="btn-ghost rounded-btn btn border-none hover:bg-secondary hover:text-white"
+              >
                 <MenuIcon />
               </label>
               <ul
                 tabIndex={0}
-                className="dropdown-content menu rounded-box mt-4 w-52 bg-base-200 p-2 shadow blur-0">
+                className="dropdown-content menu rounded-box mt-4 w-52 bg-base-200 p-2 shadow blur-0"
+              >
                 <div className="bg-base-200 lg:hidden">
                   <div className="stats-desc p-2 font-semibold">Navigation</div>
                   {primaryNavLinks}
@@ -186,7 +186,7 @@ function NavBar({ user }: Props) {
           </div>
         </div>
       </div>
-      {atDashboard && <DonationBanner />}
+      {pathname === "/dashboard" && <DonationBanner />}
     </>
   )
 }

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -11,6 +11,7 @@ import {
   TrophyIcon,
   UserIcon,
 } from 'lucide-react'
+import { useTheme } from 'next-themes'
 import Image from 'next/image'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
@@ -24,22 +25,13 @@ interface Props {
 function NavBar({ user }: Props) {
   const pathname = usePathname()
   const atDashboard = pathname === '/dashboard'
-
-  const [theme, setTheme] = useState(
-    typeof window !== 'undefined' ? localStorage.getItem('theme') ?? 'light' : 'light'
-  )
-
-  useEffect(() => {
-    document.documentElement.setAttribute('data-theme', theme)
-  }, [theme])
+  const { theme, setTheme } = useTheme()
 
   const handleThemeChange = () => {
     if (theme === 'light') {
       setTheme('dark')
-      localStorage?.setItem('theme', 'dark')
     } else {
       setTheme('light')
-      localStorage?.setItem('theme', 'light')
     }
   }
 
@@ -90,9 +82,8 @@ function NavBar({ user }: Props) {
           href="https://pepiti.com/stats/api/v0/steam_login"
           target="_blank"
           referrerPolicy="origin"
-          className={`btn-ghost btn mt-[2px] h-full w-full border-none text-error ${
-            user.guid ? 'btn-error' : ''
-          }`}>
+          className={`btn-ghost btn mt-[2px] h-full w-full border-none text-error ${user.guid ? 'btn-error' : ''
+            }`}>
           {user.guid ? 'Change User' : 'Sign In'}
         </Link>
       ),
@@ -159,14 +150,14 @@ function NavBar({ user }: Props) {
           <div className="navbar-start">
             <Link
               href="/dashboard"
-              className="btn-ghost btn border-none hover:bg-secondary hover:text-white">
+              className="btn-ghost btn border-none hover:bg-secondary hover:text-white relative w-14">
               <Image
                 priority={true}
                 src="/assets/brand/pepiti-logo.svg"
-                className="w-h-10 h-10"
+                fill
                 alt="pepiti_brand"
-                width={50}
-                height={50}
+                placeholder='blur'
+                blurDataURL='/assets/brand/pepiti-logo.svg'
               />
             </Link>
           </div>


### PR DESCRIPTION
Closes #4

Did not abstract into ThemeSwitch component because NavBar has to remain 'use client' anyway. I also don't see switching the theme anywhere else? Got rid of hydration warning for me.

## 🎯 Changes
- add: next-themes
- improved: navbar theme switcher
- fixed: hydration warning
- fixed: some home page image preload warnings
