### PR TITLE
pagination to top record tables, added hidePerPage prop to Table

### DIFF
--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -15,9 +15,9 @@ export const metadata = {
 
 export default async function Page() {
   const apiStats = await GetSummaryStats()
-  const worldRecords = await GetDynamicTopRecords("riders", 10)
-  const worldMMR = await GetDynamicTopRecords("mmr", 10)
-  const worldSR = await GetDynamicTopRecords("sr", 10)
+  const worldRecords = await GetDynamicTopRecords("riders", 30)
+  const worldMMR = await GetDynamicTopRecords("mmr", 100)
+  const worldSR = await GetDynamicTopRecords("sr", 100)
   const trackList = await GetTrackNames()
 
   return (

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -38,6 +38,7 @@ interface TableColumn {
  */
 export interface TableOptions {
   paginationEnabled?: boolean
+  hidePerPage?: boolean
   pageSize?: number
   searchEnabled?: boolean
   searchKey?: string
@@ -58,6 +59,7 @@ interface TableProps extends TableOptions {
 
 const Table: React.FC<TableProps> = (props) => {
   const {
+    hidePerPage = false,
     paginationEnabled = false,
     pageSize: pageSizeOption = 10,
     searchEnabled = false,
@@ -209,37 +211,39 @@ const Table: React.FC<TableProps> = (props) => {
         </table>
       </div>
       {paginationEnabled && (
-        <div className="mt-4 flex flex-col items-center justify-between md:flex-row">
+        <div className="mt-4 flex flex-col items-center justify-between px-3 text-sm md:flex-row">
           <div className="mb-2 mr-5 md:mb-0">
-            Page: {page + 1} / {Math.floor(data.length / pageSize) + 1}
+            Page: {page + 1} / {Math.floor(data.length / pageSize)}
           </div>
-          <div className="flex gap-2">
+          <div className="flex items-center gap-2">
             <div className="btn-group">
               <button
-                className="btn-ghost btn-sm btn bg-base-100"
+                className="btn-ghost btn-xs btn bg-base-100"
                 onClick={() => handlePageChange(page > 0 ? page - 1 : page)}
                 disabled={page === 0}
               >
                 Prev Page
               </button>
               <button
-                className="btn-ghost btn-sm btn bg-base-100"
+                className="btn-ghost btn-xs btn bg-base-100"
                 onClick={() => handlePageChange(paginatedData.length ? page + 1 : page)}
-                disabled={paginatedData.length < pageSize}
+                disabled={page + 1 === Math.floor(data.length / pageSize)}
               >
                 Next Page
               </button>
             </div>
-            <select
-              className="input input-sm"
-              value={pageSize}
-              onChange={(e) => handlePageSizeChange(e.target.value)}
-            >
-              <option value={10}>10</option>
-              <option value={25}>25</option>
-              <option value={50}>50</option>
-              <option value={100}>100</option>
-            </select>
+            {!hidePerPage && (
+              <select
+                className="input input-sm"
+                value={pageSize}
+                onChange={(e) => handlePageSizeChange(e.target.value)}
+              >
+                <option value={10}>10</option>
+                <option value={25}>25</option>
+                <option value={50}>50</option>
+                <option value={100}>100</option>
+              </select>
+            )}
           </div>
         </div>
       )}

--- a/src/components/tables/MMRRecordsTable.tsx
+++ b/src/components/tables/MMRRecordsTable.tsx
@@ -29,12 +29,12 @@ export default function MMRRecordsTable({ worldMMR, seeMore, ...rest }: Props) {
 
   return (
     <div className="flex flex-col items-end">
-      <Table columns={columns} data={worldMMR.riders} {...rest} />
-      {seeMore && (
+      <Table columns={columns} data={worldMMR.riders} paginationEnabled hidePerPage {...rest} />
+      {/* {seeMore && (
         <Link href="/top/mmr" className="link pt-2 text-sm text-primary no-underline">
           See More
         </Link>
-      )}
+      )} */}
     </div>
   )
 }

--- a/src/components/tables/SRRecordsTable.tsx
+++ b/src/components/tables/SRRecordsTable.tsx
@@ -29,12 +29,12 @@ export default function SRRecordsTable({ worldSR, seeMore, ...rest }: Props) {
 
   return (
     <div className="flex flex-col items-end">
-      <Table columns={columns} data={worldSR.riders} {...rest} />
-      {seeMore && (
+      <Table columns={columns} paginationEnabled hidePerPage data={worldSR.riders} {...rest} />
+      {/* {seeMore && (
         <Link href="/top/sr" className="link pt-2 text-sm text-primary no-underline">
           See More
         </Link>
-      )}
+      )} */}
     </div>
   )
 }

--- a/src/components/tables/WorldRecordsTable.tsx
+++ b/src/components/tables/WorldRecordsTable.tsx
@@ -35,12 +35,12 @@ export default function WorldRecordsTable({ worldRecords, seeMore, ...rest }: Pr
 
   return (
     <div className="flex flex-col items-end">
-      <Table columns={columns} data={data} {...rest} />
-      {seeMore && (
+      <Table columns={columns} paginationEnabled hidePerPage data={data} {...rest} />
+      {/* {seeMore && (
         <Link href="/top/riders" className="link pt-2 text-sm text-primary no-underline">
           See More
         </Link>
-      )}
+      )} */}
     </div>
   )
 }


### PR DESCRIPTION
Feature for pagination to top tables in dash. Should we still add the link to see the expanded tables?

## 🎯 Changes
- add: hidePerPage prop to Table
- change: ui styling to pagination data
- fix: some logic in page changes
