### PR TITLE
Table sorting options, and DX

### DIFF
--- a/src/app/(app)/dashboard/components/TopRecords.tsx
+++ b/src/app/(app)/dashboard/components/TopRecords.tsx
@@ -1,0 +1,49 @@
+import Link from "next/link"
+import WorldRecordsTable from "~/components/tables/WorldRecordsTable"
+import MMRRecordsTable from "~/components/tables/MMRRecordsTable"
+import SRRecordsTable from "~/components/tables/SRRecordsTable"
+import { Popover, PopoverContent, PopoverTrigger } from "~/ui/Popover"
+import { MoreHorizontal } from "lucide-react"
+
+export default function TopRecords({ worldRecords, worldMMR, worldSR }) {
+  return (
+    <div>
+      <div className="flex justify-end">
+        <Popover>
+          <PopoverTrigger className="mt-4 flex justify-center">
+            <MoreHorizontal />
+          </PopoverTrigger>
+          <PopoverContent className="flex justify-center">
+            <Link
+              href="/records"
+              className="hover:bg-border btn-ghost btn-sm btn w-fit hover:bg-transparent hover:text-secondary"
+            >
+              See all Top Records
+            </Link>
+          </PopoverContent>
+        </Popover>
+      </div>
+      <div className="grid gap-5 lg:grid-cols-3">
+        <div>
+          <Link href="/records/top/riders">
+            <div className="mb-2 text-lg font-semibold">Top Records</div>
+          </Link>
+          <WorldRecordsTable worldRecords={worldRecords} sortingEnabled={false} />
+        </div>
+        <div>
+          <Link href="/records/top/mmr">
+            <div className="mb-2 text-lg font-semibold">Top MMR</div>
+          </Link>
+          <MMRRecordsTable worldMMR={worldMMR} sortingEnabled={false} />
+        </div>
+        <div>
+          <Link href="/records/top/sr" className=" flex items-start gap-2">
+            <div className="mb-2 text-lg font-semibold">Top SR</div>
+            <div className="text-sm text-accent">(Safety Rating)</div>
+          </Link>
+          <SRRecordsTable worldSR={worldSR} sortingEnabled={false} />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -2,10 +2,8 @@ import { GetDynamicTopRecords, GetSummaryStats, GetTrackNames } from "~/api"
 import PageHeader from "~/components/PageHeader"
 import RiderSearch from "./components/RiderSearch"
 import SummaryStats from "./components/Summary"
+import TopRecords from "./components/TopRecords"
 import TrackRecords from "./components/TrackRecords"
-import WorldRecordsTable from "~/components/tables/WorldRecordsTable"
-import MMRRecordsTable from "~/components/tables/MMRRecordsTable"
-import SRRecordsTable from "~/components/tables/SRRecordsTable"
 
 export const metadata = {
   title: "Pepiti | Dashboard",
@@ -27,23 +25,7 @@ export default async function Page() {
       <div className="mx-auto flex w-full flex-col gap-16">
         <SummaryStats stats={apiStats} />
 
-        <div className="grid gap-5 lg:grid-cols-3">
-          <div>
-            <div className="pb-2 text-lg font-semibold">Top Records</div>
-            <WorldRecordsTable worldRecords={worldRecords} sortingEnabled={false} />
-          </div>
-          <div>
-            <div className="pb-2 text-lg font-semibold">Top MMR</div>
-            <MMRRecordsTable worldMMR={worldMMR} sortingEnabled={false} />
-          </div>
-          <div>
-            <div className="flex items-center gap-2 pb-2">
-              <div className="text-lg font-semibold">Top SR</div>
-              <div className="text-sm text-accent">(Safety Rating)</div>
-            </div>
-            <SRRecordsTable worldSR={worldSR} sortingEnabled={false} />
-          </div>
-        </div>
+        <TopRecords worldRecords={worldRecords} worldMMR={worldMMR} worldSR={worldSR} />
 
         <TrackRecords trackList={trackList.tracks} />
       </div>

--- a/src/app/(app)/leagues/_components/LeagueOverview.tsx
+++ b/src/app/(app)/leagues/_components/LeagueOverview.tsx
@@ -216,11 +216,6 @@ const LeagueStandings = ({ league }: { league: League }) => {
 
   const columns = [
     {
-      key: "name",
-      label: "Rider",
-      render: (name, row) => <RiderLink href={`/profile/${row.guid}`}>{name}</RiderLink>,
-    },
-    {
       key: "race_number",
       label: "Race #",
       render: (race_number) => (
@@ -229,6 +224,11 @@ const LeagueStandings = ({ league }: { league: League }) => {
           <div className="text-secondary">{race_number}</div>
         </div>
       ),
+    },
+    {
+      key: "name",
+      label: "Rider",
+      render: (name, row) => <RiderLink href={`/profile/${row.guid}`}>{name}</RiderLink>,
     },
     {
       key: "score",
@@ -246,5 +246,12 @@ const LeagueStandings = ({ league }: { league: League }) => {
     },
   ]
 
-  return <Table data={data} columns={columns} />
+  return (
+    <Table
+      data={data}
+      columns={columns}
+      sortingEnabled={true}
+      sortingKeys={["name", "score", "bike_id", "team"]}
+    />
+  )
 }

--- a/src/app/(app)/leagues/_components/LeagueRaceOverview.tsx
+++ b/src/app/(app)/leagues/_components/LeagueRaceOverview.tsx
@@ -203,5 +203,12 @@ const LeagueRaceStandings = ({ division }: { division: LeagueRaceDivision }) => 
     },
   ]
 
-  return <Table data={data} columns={columns} />
+  return (
+    <Table
+      data={data}
+      columns={columns}
+      sortingEnabled={true}
+      sortingKeys={["lapTime", "averageSpeed", "split1", "split2"]}
+    />
+  )
 }

--- a/src/app/(app)/profile/[guid]/components/tabs/RiderRacesTable.tsx
+++ b/src/app/(app)/profile/[guid]/components/tabs/RiderRacesTable.tsx
@@ -94,6 +94,17 @@ export default function RiderRacesTable({ guid }: Props) {
       searchEnabled={true}
       paginationEnabled={true}
       sortingEnabled={true}
+      sortingKeys={[
+        "date",
+        "track",
+        "position",
+        "gap",
+        "laps",
+        "penalties",
+        "fastestLap",
+        "mmrGain",
+        "newMMR",
+      ]}
     />
   )
 }

--- a/src/app/(app)/profile/[guid]/components/tabs/RiderRecordsTable.tsx
+++ b/src/app/(app)/profile/[guid]/components/tabs/RiderRecordsTable.tsx
@@ -83,6 +83,7 @@ export default function RiderRecordsTable({ guid }: Props) {
       searchEnabled={true}
       paginationEnabled={true}
       sortingEnabled={true}
+      sortingKeys={["date", "track", "lapTime", "split1", "split2", "averageSpeed"]}
     />
   )
 }

--- a/src/app/(app)/records/[top]/page.tsx
+++ b/src/app/(app)/records/[top]/page.tsx
@@ -8,9 +8,11 @@ import ContactRecordsTable from "~/components/tables/ContactRecordsTable"
 import Result from "~/components/Result"
 
 export async function generateMetadata({ params: { top } }) {
+  if (!dynamicDataMap[top]) return { title: "Not Found" }
+
   return {
-    title: `Pepiti | Records`,
-    description: dynamicDataMap[top] ? `Top ${dynamicDataMap[top].title}` : "",
+    title: `Pepiti | Top Records`,
+    description: `Top ${dynamicDataMap[top].title}`,
   }
 }
 
@@ -39,6 +41,7 @@ const tableProps = {
   searchEnabled: true,
   paginationEnabled: true,
   jumpToEnabled: true,
+  sortingEnabled: true,
 }
 const dynamicDataMap = {
   riders: {

--- a/src/app/(app)/records/page.tsx
+++ b/src/app/(app)/records/page.tsx
@@ -1,0 +1,97 @@
+import PageHeader from "~/components/PageHeader"
+import { NewspaperIcon } from "lucide-react"
+import Link from "next/link"
+
+export async function generateMetadata() {
+  return {
+    title: `Pepiti | Records`,
+    description: "Records with an in depth view",
+  }
+}
+
+export default async function Page() {
+  return (
+    <div className="mx-auto w-full max-w-[1000px]">
+      <PageHeader
+        title="Pepiti Records"
+        extra={
+          <Link href="/dashboard" className="no-underline">
+            Go back
+          </Link>
+        }
+      />
+      <Records />
+    </div>
+  )
+}
+
+const Records = () => {
+  return (
+    <div className="md: mt-6 grid grid-cols-1 md:grid-cols-3 md:px-4">
+      <div className="mr-4 flex flex-col">
+        <div className="my-4 text-xl font-semibold">World Records</div>
+        <Link
+          href="/records/riders"
+          className="card card-body mb-2 flex w-[300px] cursor-pointer bg-base-200 no-underline hover:bg-secondary"
+        >
+          <div className="flex">
+            <NewspaperIcon />
+            <div className="ml-4">Record Holders</div>
+          </div>
+        </Link>
+      </div>
+
+      <div className="mr-4 flex flex-col">
+        <div className="my-4 text-xl font-semibold">MMR</div>
+        <Link
+          href="/records/mmr"
+          className="card card-body mb-2 flex w-[300px] cursor-pointer bg-base-200 no-underline hover:bg-secondary"
+        >
+          <div className="flex">
+            <NewspaperIcon />
+            <div className="ml-4">Top MMR Rankings</div>
+          </div>
+        </Link>
+      </div>
+
+      <div className="mr-4 flex flex-col">
+        <div className="my-4 text-xl font-semibold">SR</div>
+        <Link
+          href="/records/sr"
+          className="card card-body mb-2 flex w-[300px] cursor-pointer bg-base-200 no-underline hover:bg-secondary"
+        >
+          <div className="flex">
+            <NewspaperIcon />
+            <div className="ml-4">Top MMR Rankings</div>
+          </div>
+        </Link>
+      </div>
+
+      <div className="mr-4 flex flex-col">
+        <div className="my-4 text-xl font-semibold">Bikes</div>
+        <Link
+          href="/records/bikes"
+          className="card card-body mb-2 flex w-[300px] cursor-pointer bg-base-200 no-underline hover:bg-secondary"
+        >
+          <div className="flex">
+            <NewspaperIcon />
+            <div className="ml-4">Bike Lap Totals</div>
+          </div>
+        </Link>
+      </div>
+
+      <div className="mr-4 flex flex-col">
+        <div className="my-4 text-xl font-semibold">Contacts</div>
+        <Link
+          href="/records/contacts"
+          className="card card-body mb-2 flex w-[300px] cursor-pointer bg-base-200 no-underline hover:bg-secondary"
+        >
+          <div className="flex">
+            <NewspaperIcon />
+            <div className="ml-4">Most Unaware Riders</div>
+          </div>
+        </Link>
+      </div>
+    </div>
+  )
+}

--- a/src/app/(wide)/races/[raceId]/components/MMRAnalysisTable.tsx
+++ b/src/app/(wide)/races/[raceId]/components/MMRAnalysisTable.tsx
@@ -81,5 +81,12 @@ export default function MMRAnalysisTable({ standings }: Props) {
     },
   ]
 
-  return <Table columns={columns} data={standings} sortingEnabled={true} />
+  return (
+    <Table
+      columns={columns}
+      data={standings}
+      sortingEnabled={true}
+      sortingKeys={["mmrGain", "newMmr", "bpp", "prb", "nrb", "fl", "hs"]}
+    />
+  )
 }

--- a/src/app/(wide)/races/[raceId]/components/RaceStandingsTable.tsx
+++ b/src/app/(wide)/races/[raceId]/components/RaceStandingsTable.tsx
@@ -12,11 +12,6 @@ interface Props {
 export default function RaceStandingsTable({ standings }: Props) {
   const tableColumns = [
     {
-      key: "name",
-      label: "Name",
-      render: (name, row) => <RiderLink href={`/profile/${row._id}`}>{name}</RiderLink>,
-    },
-    {
       key: "raceNumber",
       label: "Race #",
       render: (raceNumber) => (
@@ -25,6 +20,11 @@ export default function RaceStandingsTable({ standings }: Props) {
           <div className="text-primary">{raceNumber}</div>
         </div>
       ),
+    },
+    {
+      key: "name",
+      label: "Name",
+      render: (name, row) => <RiderLink href={`/profile/${row._id}`}>{name}</RiderLink>,
     },
     {
       key: "position",
@@ -61,7 +61,12 @@ export default function RaceStandingsTable({ standings }: Props) {
 
   return (
     <>
-      <Table columns={tableColumns} data={standings} sortingEnabled={true} />
+      <Table
+        columns={tableColumns}
+        data={standings}
+        sortingEnabled={true}
+        sortingKeys={["position", "gap", "raceTime", "laps", "penalty", "fastestLap"]}
+      />
     </>
   )
 }

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -38,6 +38,7 @@ export interface TableOptions {
   paginationEnabled?: boolean
   jumpToEnabled?: boolean
   defaultPageSize?: number
+  sortingKeys?: Array<string>
   sortingEnabled?: boolean
   searchEnabled?: boolean
   searchKey?: string
@@ -58,6 +59,7 @@ const Table: React.FC<TableProps> = (props) => {
     paginationEnabled = false,
     jumpToEnabled = true,
     defaultPageSize = 10,
+    sortingKeys = [],
     sortingEnabled = false,
     searchEnabled = false,
     searchKey = "name",
@@ -116,7 +118,13 @@ const Table: React.FC<TableProps> = (props) => {
 
   /** maps prepped columns to header row */
   const tableColumns = columns.map((column) => {
+    const isRankColumn = column.key === "rank"
+    const columnIsSortable =
+      sortingKeys.some((k) => k === column.key) && !isRankColumn && sortingEnabled
+
     const handleHeaderClick = (key) => {
+      if (!columnIsSortable) return
+
       const sortDirection =
         sorting.key === key ? cycleSortingDirection(sorting.dir) : SortDirection.Ascending
       const sortData = sortDataByColumn(data, key, sortDirection)
@@ -132,6 +140,8 @@ const Table: React.FC<TableProps> = (props) => {
     }
 
     const SortingControls = () => {
+      if (!columnIsSortable) return <></>
+
       const isColumnSorting = sorting.key === column.key
 
       return (
@@ -150,12 +160,12 @@ const Table: React.FC<TableProps> = (props) => {
     return (
       <th
         key={column.key}
-        className={`group py-4 ${sortingEnabled ? "cursor-pointer" : ""}`}
-        onClick={() => sortingEnabled && handleHeaderClick(column.key)}
+        className={`group py-4 ${columnIsSortable ? "cursor-pointer" : ""}`}
+        onClick={() => handleHeaderClick(column.key)}
       >
         <div className={"flex select-none items-center gap-4"}>
           {column.label}
-          {sortingEnabled && <SortingControls />}
+          <SortingControls />
         </div>
       </th>
     )

--- a/src/components/Table/index.ts
+++ b/src/components/Table/index.ts
@@ -25,20 +25,24 @@ export const sortDataByColumn = (
   dir: SortDirection
 ): Array<TableData> => {
   return data.sort((a, b) => {
-    let res: number =
-      typeof a[key] === "string"
-        ? stringCompare(a[key] ?? "", b[key] ?? "")
-        : typeof a[key] === "number"
-        ? numberCompare(a[key] ?? 0, b[key] ?? 0)
-        : typeof a[key] === "boolean"
-        ? booleanCompare(a[key] ?? false, b[key] ?? false)
-        : -1
+    let res: number
 
-    if (res === 0) res = data.indexOf(a) - data.indexOf(b)
+    if (typeof a[key] === "string") {
+      res = stringCompare(a[key] ?? "", b[key] ?? "")
+    } else if (typeof a[key] === "number") {
+      res = numberCompare(a[key] ?? 0, b[key] ?? 0)
+    } else if (typeof a[key] === "boolean") {
+      res = booleanCompare(a[key] ?? false, b[key] ?? false)
+    } else {
+      throw new Error("Invalid column type")
+    }
+
+    if (res === 0) res = data.indexOf(b) - data.indexOf(a)
     if (dir === "desc") res = -res
 
     return res
   })
+  
 }
 
 const stringCompare = (a: string, b: string): number => a.localeCompare(b)

--- a/src/components/tables/BikeRecordsTable.tsx
+++ b/src/components/tables/BikeRecordsTable.tsx
@@ -33,7 +33,7 @@ export default function BikeRecordsTable({ worldBikes, ...rest }: Props) {
 
   return (
     <div className="flex flex-col items-end">
-      <Table data={data} columns={columns} {...rest} />
+      <Table data={data} columns={columns} sortingKeys={["laps"]} {...rest} />
     </div>
   )
 }

--- a/src/components/tables/ContactRecordsTable.tsx
+++ b/src/components/tables/ContactRecordsTable.tsx
@@ -34,7 +34,7 @@ export default function ContactRecordsTable({ worldContacts, ...rest }: Props) {
 
   return (
     <div className="flex flex-col items-end">
-      <Table data={data} columns={columns} {...rest} />
+      <Table data={data} columns={columns} sortingKeys={["score"]} {...rest} />
     </div>
   )
 }

--- a/src/components/tables/MMRRecordsTable.tsx
+++ b/src/components/tables/MMRRecordsTable.tsx
@@ -39,6 +39,7 @@ export default function MMRRecordsTable({ worldMMR, ...rest }: Props) {
         columns={columns}
         paginationEnabled={true}
         jumpToEnabled={false}
+        sortingKeys={["score"]}
         {...rest}
       />
     </div>

--- a/src/components/tables/SRRecordsTable.tsx
+++ b/src/components/tables/SRRecordsTable.tsx
@@ -39,6 +39,7 @@ export default function SRRecordsTable({ worldSR, ...rest }: Props) {
         columns={columns}
         paginationEnabled={true}
         jumpToEnabled={false}
+        sortingKeys={["score"]}
         {...rest}
       />
     </div>

--- a/src/components/tables/TrackRecordsTable.tsx
+++ b/src/components/tables/TrackRecordsTable.tsx
@@ -57,6 +57,7 @@ export const TrackRecordsTable = ({ records }: Props) => {
       searchEnabled={true}
       paginationEnabled={true}
       sortingEnabled={true}
+      sortingKeys={["lap_time", "average_speed", "split_1", "split_2"]}
     />
   )
 }

--- a/src/components/tables/WorldRecordsTable.tsx
+++ b/src/components/tables/WorldRecordsTable.tsx
@@ -41,6 +41,7 @@ export default function WorldRecordsTable({ worldRecords, ...rest }: Props) {
         columns={columns}
         paginationEnabled={true}
         jumpToEnabled={false}
+        sortingKeys={["records"]}
         {...rest}
       />
     </div>


### PR DESCRIPTION
Closes #

## 🎯 Changes
- add: Table sorting options for enabling columns individually
- add: Dashboard see more Top records popover link
- /records page WIP to show list of top records tables

ex: 
```
   <Table
      columns={columns}
      data={records}
      sortingEnabled={true} // must enable for keys to take effect
      sortingKeys={["date", "track", "lapTime", "split1", "split2", "averageSpeed"]}
  />
```