### PR TITLE
Expandable rows

### DIFF
--- a/src/app/(app)/admin/blacklists/components/BlacklistTable.tsx
+++ b/src/app/(app)/admin/blacklists/components/BlacklistTable.tsx
@@ -4,7 +4,7 @@ import { useSearchParams } from "next/navigation"
 import Table from "~/components/Table/Table"
 import RiderLink from "~/components/RiderLink"
 import Pill from "~/components/pills/Pill"
-import UnbanRiderButton from "~/components/actions/UnbanRiderButton"
+import BlacklistRiderStatsRow from "../../../../../components/tables/expandable/BlacklistRiderStatsRow"
 
 interface Props {
   blacklist: any
@@ -56,7 +56,7 @@ export default function BlacklistTable({ blacklist, isAdministrating }: Props) {
       sortingEnabled={true}
       sortingKeys={sortKeys}
       expandable={{
-        render: (row) => <BlacklistRiderRow row={row} isAdministrating={isAdministrating} />,
+        render: (row) => <BlacklistRiderStatsRow row={row} isAdministrating={isAdministrating} />,
       }}
     />
   )
@@ -74,37 +74,4 @@ const renderBannedBy = (reason) => {
     default:
       return "secondary"
   }
-}
-
-function BlacklistRiderRow({ row, isAdministrating }) {
-  const columns: any = []
-  const adminColumn = {
-    key: "guid",
-    label: "Admin",
-    width: "w-full",
-    render: (guid, row) => <UnbanRiderButton riderId={guid} name={row.name} hackit={true} />,
-  }
-
-  if (isAdministrating) columns.push(adminColumn)
-
-  const riderColumns = [
-    {
-      key: "MMR",
-      label: "MMR",
-      render: (MMR) => <Pill text={MMR} />,
-    },
-    {
-      key: "SR",
-      label: "SR",
-      render: (SR) => <Pill text={SR} />,
-    },
-    {
-      key: "contact",
-      label: "Contacts",
-      render: (contact) => <Pill text={contact} />,
-    },
-  ]
-  columns.push(...riderColumns)
-
-  return <Table data={[row]} columns={columns} rankEnabled={false} />
 }

--- a/src/app/(app)/leagues/_components/LeagueOverview.tsx
+++ b/src/app/(app)/leagues/_components/LeagueOverview.tsx
@@ -244,12 +244,14 @@ const LeagueStandings = ({ league }: { league: League }) => {
     },
   ]
 
+  const sortKeys = ["name", "score", "bike_id", "team"]
+
   return (
     <Table
       data={data}
       columns={columns}
       sortingEnabled={true}
-      sortingKeys={["name", "score", "bike_id", "team"]}
+      sortingKeys={sortKeys}
     />
   )
 }

--- a/src/app/(app)/leagues/_components/LeagueRaceOverview.tsx
+++ b/src/app/(app)/leagues/_components/LeagueRaceOverview.tsx
@@ -203,12 +203,14 @@ const LeagueRaceStandings = ({ division }: { division: LeagueRaceDivision }) => 
     },
   ]
 
+  const sortKeys = ["lapTime", "averageSpeed", "split1", "split2"]
+
   return (
     <Table
       data={data}
       columns={columns}
       sortingEnabled={true}
-      sortingKeys={["lapTime", "averageSpeed", "split1", "split2"]}
+      sortingKeys={sortKeys}
     />
   )
 }

--- a/src/app/(app)/profile/[guid]/components/ProfileTabs.tsx
+++ b/src/app/(app)/profile/[guid]/components/ProfileTabs.tsx
@@ -6,6 +6,7 @@ import RiderMMRHistoryChart from "./tabs/RiderMMRHistoryChart"
 import RiderRacesTable from "./tabs/RiderRacesTable"
 import RiderRecordsTable from "./tabs/RiderRecordsTable"
 import RiderLeaguesList from "./tabs/RiderLeaguesList"
+import { usePathname, useRouter, useSearchParams } from "next/navigation"
 
 interface Props {
   user: User
@@ -15,6 +16,10 @@ interface Props {
 }
 
 export default function ProfileTabs({ user, rider, mmrHistory, leagues }: Props) {
+  const router = useRouter()
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+  const tabParam = searchParams.get("tab")!
   const isUserProfile = user.guid === rider._id
 
   const items = [
@@ -64,7 +69,12 @@ export default function ProfileTabs({ user, rider, mmrHistory, leagues }: Props)
 
   return (
     <div className="card-body mt-20 rounded-lg bg-base-200 p-0">
-      <Tabs items={items} wide={true} />
+      <Tabs
+        items={items}
+        wide={true}
+        defaultActive={tabParam}
+        onChange={(item) => router.push(`${pathname}?tab=${item.key}`)}
+      />
     </div>
   )
 }

--- a/src/app/(app)/profile/[guid]/components/tabs/RiderRacesTable.tsx
+++ b/src/app/(app)/profile/[guid]/components/tabs/RiderRacesTable.tsx
@@ -91,6 +91,8 @@ export default function RiderRacesTable({ guid }: Props) {
     },
   ]
 
+  const sortKeys = ["date", "track", "position", "gap", "laps", "penalties", "mmrGain", "newMMR"]
+
   return (
     <Table
       columns={columns}
@@ -100,7 +102,7 @@ export default function RiderRacesTable({ guid }: Props) {
       searchEnabled={true}
       paginationEnabled={true}
       sortingEnabled={true}
-      sortingKeys={["date", "track", "position", "gap", "laps", "penalties", "mmrGain", "newMMR"]}
+      sortingKeys={sortKeys}
     />
   )
 }

--- a/src/app/(app)/profile/[guid]/components/tabs/RiderRecordsTable.tsx
+++ b/src/app/(app)/profile/[guid]/components/tabs/RiderRecordsTable.tsx
@@ -73,6 +73,8 @@ export default function RiderRecordsTable({ guid }: Props) {
       render: (bike) => <BikeWithPrefixColor bike={bike} />,
     },
   ]
+  
+  const sortKeys = ["date", "track", "lapTime", "split1", "split2", "averageSpeed"]
 
   return (
     <Table
@@ -83,7 +85,7 @@ export default function RiderRecordsTable({ guid }: Props) {
       searchEnabled={true}
       paginationEnabled={true}
       sortingEnabled={true}
-      sortingKeys={["date", "track", "lapTime", "split1", "split2", "averageSpeed"]}
+      sortingKeys={sortKeys}
     />
   )
 }

--- a/src/app/(app)/records/[top]/components/DynamicTableRenderer.tsx
+++ b/src/app/(app)/records/[top]/components/DynamicTableRenderer.tsx
@@ -5,9 +5,9 @@ import WorldRecordsRiderRecordsRow from "~/components/tables/expandable/WorldRec
 import MMRRecordsTable from "~/components/tables/MMRRecordsTable"
 import MMRRecordsRiderRacesRow from "~/components/tables/expandable/MMRRecordsRiderRacesRow"
 import SRRecordsTable from "~/components/tables/SRRecordsTable"
+import SRRecordsRiderRacesRow from "~/components/tables/expandable/SRRecordsRiderStatsRow"
 import BikeRecordsTable from "~/components/tables/BikeRecordsTable"
 import ContactRecordsTable from "~/components/tables/ContactRecordsTable"
-import SRRecordsRiderRacesRow from "~/components/tables/expandable/SRRecordsRiderRacesRow"
 
 export default function DynamicTableRenderer({ top, records }) {
   return dynamicDataMap[top].render(records)

--- a/src/app/(wide)/races/[raceId]/components/MMRAnalysisTable.tsx
+++ b/src/app/(wide)/races/[raceId]/components/MMRAnalysisTable.tsx
@@ -3,6 +3,7 @@ import MMRPill from "~/components/pills/MMRPill"
 import Pill from "~/components/pills/Pill"
 import RiderLink from "~/components/RiderLink"
 import Table from "~/components/Table/Table"
+import MMRRecordsRiderRacesRow from "~/components/tables/expandable/MMRRecordsRiderRacesRow"
 import { toFixedIfNecessary } from "~/utils/toFixedIfNecessary"
 
 interface Props {
@@ -81,12 +82,17 @@ export default function MMRAnalysisTable({ standings }: Props) {
     },
   ]
 
+  const sortKeys = ["mmrGain", "newMmr", "bpp", "prb", "nrb", "fl", "hs"]
+
   return (
     <Table
       columns={columns}
       data={standings}
       sortingEnabled={true}
-      sortingKeys={["mmrGain", "newMmr", "bpp", "prb", "nrb", "fl", "hs"]}
+      sortingKeys={sortKeys}
+      expandable={{
+        render: (row) => <MMRRecordsRiderRacesRow row={row} />,
+      }}
     />
   )
 }

--- a/src/app/(wide)/races/[raceId]/components/RaceStandingsTable.tsx
+++ b/src/app/(wide)/races/[raceId]/components/RaceStandingsTable.tsx
@@ -2,6 +2,7 @@ import Link from "next/link"
 import React, { useState } from "react"
 import RiderLink from "~/components/RiderLink"
 import Table from "~/components/Table/Table"
+import RecentRacesRiderStatsRow from "~/components/tables/expandable/RecentRacesAnalysisStatsRow"
 import { handleLapTimes } from "~/utils/handleLapTimes"
 import handlePlaceSuffix from "~/utils/handlePlaceSuffix"
 
@@ -59,13 +60,18 @@ export default function RaceStandingsTable({ standings }: Props) {
     },
   ]
 
+  const sortKeys = ["position", "gap", "raceTime", "laps", "penalty", "fastestLap"]
+
   return (
     <>
       <Table
         columns={tableColumns}
         data={standings}
         sortingEnabled={true}
-        sortingKeys={["position", "gap", "raceTime", "laps", "penalty", "fastestLap"]}
+        sortingKeys={sortKeys}
+        expandable={{
+          render: (row) => <RecentRacesRiderStatsRow row={row} />,
+        }}
       />
     </>
   )

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -2,6 +2,7 @@
 
 import Image from "next/image"
 import Link from "next/link"
+import RiderLink from "./RiderLink"
 
 interface Props {
   user: User
@@ -15,14 +16,18 @@ export default function Footer({ user }: Props) {
       <div className="footer mx-auto max-w-[1400px]">
         <div>
           <Image src="/assets/brand/pepiti-logo.svg" width={120} height={120} alt="pepiti_brand" />
-          <p>
-            Copyright © {date.getFullYear()} Pepiti
+          <div>
+            <div className="flex gap-2">
+              Copyright © {date.getFullYear()}{" "}
+              <RiderLink href={`/profile/FF01100001013A65F0`} name="Pepiti" />
+            </div>
+            <div className="my-1">All rights reserved</div>
+            <div className="flex gap-2">
+              Powered by <RiderLink href={`/profile/FF011000010B64EBF5`} name="Tooky" /> and{" "}
+              <RiderLink href={`/profile/FF011000010513D5FF`} name="PDR" />
+            </div>
             <br />
-            All rights reserved
-            <br />
-            Powered by Tooky and PDR
-            <br />
-          </p>
+          </div>
         </div>
         <div>
           <span className="footer-title">Services</span>

--- a/src/components/tables/BikeRecordsTable.tsx
+++ b/src/components/tables/BikeRecordsTable.tsx
@@ -31,9 +31,11 @@ export default function BikeRecordsTable({ worldBikes, ...rest }: Props) {
     },
   ]
 
+  const sortKeys = ["laps"]
+
   return (
     <div className="flex flex-col items-end">
-      <Table data={data} columns={columns} sortingKeys={["laps"]} {...rest} />
+      <Table data={data} columns={columns} sortingKeys={sortKeys} {...rest} />
     </div>
   )
 }

--- a/src/components/tables/ContactRecordsTable.tsx
+++ b/src/components/tables/ContactRecordsTable.tsx
@@ -30,9 +30,11 @@ export default function ContactRecordsTable({ worldContacts, ...rest }: Props) {
     },
   ]
 
+  const sortKeys = ["contacts"]
+
   return (
     <div className="flex flex-col items-end">
-      <Table data={data} columns={columns} sortingKeys={["contacts"]} {...rest} />
+      <Table data={data} columns={columns} sortingKeys={sortKeys} {...rest} />
     </div>
   )
 }

--- a/src/components/tables/MMRRecordsTable.tsx
+++ b/src/components/tables/MMRRecordsTable.tsx
@@ -30,6 +30,8 @@ export default function MMRRecordsTable({ worldMMR, ...rest }: Props) {
     },
   ]
 
+  const sortKeys = ["rating"]
+
   return (
     <div className="flex flex-col items-end">
       <Table
@@ -37,7 +39,7 @@ export default function MMRRecordsTable({ worldMMR, ...rest }: Props) {
         columns={columns}
         paginationEnabled={true}
         jumpToEnabled={false}
-        sortingKeys={["rating"]}
+        sortingKeys={sortKeys}
         {...rest}
       />
     </div>

--- a/src/components/tables/SRRecordsTable.tsx
+++ b/src/components/tables/SRRecordsTable.tsx
@@ -30,6 +30,8 @@ export default function SRRecordsTable({ worldSR, ...rest }: Props) {
     },
   ]
 
+  const sortKeys = ["rating"]
+
   return (
     <div className="flex flex-col items-end">
       <Table
@@ -37,7 +39,7 @@ export default function SRRecordsTable({ worldSR, ...rest }: Props) {
         columns={columns}
         paginationEnabled={true}
         jumpToEnabled={false}
-        sortingKeys={["rating"]}
+        sortingKeys={sortKeys}
         {...rest}
       />
     </div>

--- a/src/components/tables/TrackRecordsTable.tsx
+++ b/src/components/tables/TrackRecordsTable.tsx
@@ -50,6 +50,8 @@ export const TrackRecordsTable = ({ trackRecords, ...rest }: Props) => {
     },
   ]
 
+  const sortKeys = ["lap_time", "average_speed", "split_1", "split_2"]
+
   return (
     <Table
       data={data}
@@ -57,7 +59,7 @@ export const TrackRecordsTable = ({ trackRecords, ...rest }: Props) => {
       searchEnabled={true}
       paginationEnabled={true}
       sortingEnabled={true}
-      sortingKeys={["lap_time", "average_speed", "split_1", "split_2"]}
+      sortingKeys={sortKeys}
       {...rest}
     />
   )

--- a/src/components/tables/WorldRecordsTable.tsx
+++ b/src/components/tables/WorldRecordsTable.tsx
@@ -30,6 +30,8 @@ export default function WorldRecordsTable({ worldRecords, ...rest }: Props) {
     },
   ]
 
+  const sortKeys = ["records"]
+
   return (
     <div className="flex flex-col items-end">
       <Table
@@ -37,7 +39,7 @@ export default function WorldRecordsTable({ worldRecords, ...rest }: Props) {
         columns={columns}
         paginationEnabled={true}
         jumpToEnabled={false}
-        sortingKeys={["records"]}
+        sortingKeys={sortKeys}
         {...rest}
       />
     </div>

--- a/src/components/tables/expandable/BlacklistRiderStatsRow.tsx
+++ b/src/components/tables/expandable/BlacklistRiderStatsRow.tsx
@@ -1,0 +1,48 @@
+"use client"
+
+import useSWR from "swr"
+import { fetcher } from "~/api/fetcher"
+import Spinner from "~/components/Spinner"
+import UnbanRiderButton from "~/components/actions/UnbanRiderButton"
+
+export default function BlacklistRiderStatsRow({ row, isAdministrating }) {
+  const { data: rider, isLoading } = useSWR(`/rider/${row._id}`, fetcher)
+
+  if (isLoading)
+    return (
+      <div className="py-4">
+        <Spinner />
+      </div>
+    )
+
+  console.log("%cBlacklistRiderStatsRow", "color: goldenrod", { rider: rider })
+
+  return (
+    <div className="pr-4">
+      <div className="mb-2 flex w-full justify-between">
+        <div className="text-lg font-semibold">{row.name}&apos;s Stats</div>
+        {isAdministrating && (
+          <div className="text-lg font-semibold">
+            <UnbanRiderButton riderId={rider._id} name={rider.name} hackit={true} />
+          </div>
+        )}
+      </div>
+      <div className="stats flex w-full bg-base-100/60 text-center shadow-lg dark:bg-base-100">
+        <div className="stat w-full text-center">
+          <div className="stat-title">Laps</div>
+          <div className="stat-value pt-2 text-2xl">{rider.total_laps}</div>
+        </div>
+        <div className="stat w-full text-center">
+          <div className="stat-title">SR</div>
+          <div className={`stat-value pt-2 text-2xl ${rider.SR < 950 ? "text-error" : ""}`}>
+            {rider.SR}
+          </div>
+        </div>
+        <div className="stat w-full text-center">
+          <div className="stat-title">Contacts</div>
+          <div className="stat-value pt-2 text-2xl">{rider.contact}</div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/tables/expandable/MMRRecordsRiderRacesRow.tsx
+++ b/src/components/tables/expandable/MMRRecordsRiderRacesRow.tsx
@@ -22,14 +22,10 @@ export default function MMRRecordsRiderRacesRow({ row }) {
   const lastRaces = raceData.races.slice(0, 10)
 
   const data = lastRaces.map((race) => ({
-    date: parseInt(race._id.slice(0, 8), 16) * 1000,
     _id: race._id,
+    date: parseInt(race._id.slice(0, 8), 16) * 1000,
     track: race.track,
     position: race?.Classification?.Pos ?? "",
-    laps: race?.Classification?.Laps ?? "",
-    gap: race?.Classification?.Gap ?? "",
-    penalties: race?.Classification?.Penalty ?? "",
-    fastestLap: race.FastestLap,
     mmrGain: race.MMR.total,
     newMMR: race.MMR.old_MMR + race.MMR.total,
   }))
@@ -55,7 +51,6 @@ export default function MMRRecordsRiderRacesRow({ row }) {
       label: "Position",
       render: (position) => (position ? <b>{handlePlaceSuffix(position)}</b> : "-"),
     },
-
     {
       key: "mmrGain",
       label: "MMR +/-",

--- a/src/components/tables/expandable/RecentRacesAnalysisStatsRow.tsx
+++ b/src/components/tables/expandable/RecentRacesAnalysisStatsRow.tsx
@@ -1,0 +1,50 @@
+"use client"
+
+import useSWR from "swr"
+import { fetcher } from "~/api/fetcher"
+import Spinner from "~/components/Spinner"
+
+export default function RecentRacesAnalysisStatsRow({ row }) {
+  const { data: rider, isLoading } = useSWR(`/rider/${row._id}`, fetcher)
+
+  if (isLoading)
+    return (
+      <div className="py-4">
+        <Spinner />
+      </div>
+    )
+
+  console.log("%cRecentRacesAnalysisStatsRow", "color: goldenrod", { rider: rider })
+
+  return (
+    <div className="pr-4">
+      <div className="mb-2 text-lg font-semibold">{row.name}&apos;s Race Stats</div>
+      <div className="stats flex w-full bg-base-100/60 text-center shadow-lg dark:bg-base-100">
+        <div className="stat w-full text-center">
+          <div className="stat-title">First</div>
+          <div className="stat-value pt-2 text-2xl">{rider.races.first}</div>
+        </div>
+        <div className="stat w-full text-center">
+          <div className="stat-title">Second</div>
+          <div className="stat-value pt-2 text-2xl">{rider.races.second}</div>
+        </div>
+        <div className="stat w-full text-center">
+          <div className="stat-title">Third</div>
+          <div className="stat-value pt-2 text-2xl">{rider.races.third}</div>
+        </div>
+        <div className="stat w-full text-center">
+          <div className="stat-title">Races</div>
+          <div className="stat-value pt-2 text-2xl">{rider.races.total_races}</div>
+        </div>
+        <div className="stat w-full text-center">
+          <div className="stat-title">Fastest Laps</div>
+          <div className="stat-value pt-2 text-2xl">{rider.races.fastlap}</div>
+        </div>
+        <div className="stat w-full text-center">
+          <div className="stat-title">Holeshots</div>
+          <div className="stat-value pt-2 text-2xl">{rider.races.holeshot}</div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/tables/expandable/RecentRacesStandingsStatsRow.tsx
+++ b/src/components/tables/expandable/RecentRacesStandingsStatsRow.tsx
@@ -1,0 +1,50 @@
+"use client"
+
+import useSWR from "swr"
+import { fetcher } from "~/api/fetcher"
+import Spinner from "~/components/Spinner"
+
+export default function RecentRacesStandingsStatsRow({ row }) {
+  const { data: rider, isLoading } = useSWR(`/rider/${row._id}`, fetcher)
+
+  if (isLoading)
+    return (
+      <div className="py-4">
+        <Spinner />
+      </div>
+    )
+
+  console.log("%cRecentRacesStandingsStatsRow", "color: goldenrod", { rider: rider })
+
+  return (
+    <div className="pr-4">
+      <div className="mb-2 text-lg font-semibold">{row.name}&apos;s Race Stats</div>
+      <div className="stats flex w-full bg-base-100/60 text-center shadow-lg dark:bg-base-100">
+        <div className="stat w-full text-center">
+          <div className="stat-title">First</div>
+          <div className="stat-value pt-2 text-2xl">{rider.races.first}</div>
+        </div>
+        <div className="stat w-full text-center">
+          <div className="stat-title">Second</div>
+          <div className="stat-value pt-2 text-2xl">{rider.races.second}</div>
+        </div>
+        <div className="stat w-full text-center">
+          <div className="stat-title">Third</div>
+          <div className="stat-value pt-2 text-2xl">{rider.races.third}</div>
+        </div>
+        <div className="stat w-full text-center">
+          <div className="stat-title">Races</div>
+          <div className="stat-value pt-2 text-2xl">{rider.races.total_races}</div>
+        </div>
+        <div className="stat w-full text-center">
+          <div className="stat-title">Fastest Laps</div>
+          <div className="stat-value pt-2 text-2xl">{rider.races.fastlap}</div>
+        </div>
+        <div className="stat w-full text-center">
+          <div className="stat-title">Holeshots</div>
+          <div className="stat-value pt-2 text-2xl">{rider.races.holeshot}</div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/tables/expandable/SRRecordsRiderStatsRow.tsx
+++ b/src/components/tables/expandable/SRRecordsRiderStatsRow.tsx
@@ -4,7 +4,7 @@ import useSWR from "swr"
 import { fetcher } from "~/api/fetcher"
 import Spinner from "~/components/Spinner"
 
-export default function SRRecordsRiderRacesRow({ row }) {
+export default function SRRecordsRiderStatsRow({ row }) {
   const { data: rider, isLoading } = useSWR(`/rider/${row._id}`, fetcher)
 
   if (isLoading)
@@ -14,7 +14,7 @@ export default function SRRecordsRiderRacesRow({ row }) {
       </div>
     )
 
-  console.log("%cSRRecordsRiderRacesRow", "color: goldenrod", { races: rider })
+  console.log("%cSRRecordsRiderStatsRow", "color: goldenrod", { rider: rider })
 
   return (
     <div className="pr-4">
@@ -23,7 +23,7 @@ export default function SRRecordsRiderRacesRow({ row }) {
         <div className="stat w-full text-center">
           <div className="stat-title">Laps</div>
           <div className="stat-value py-2 text-2xl">{rider.total_laps}</div>
-          <div className="stat-description">Total Laps</div>
+          <div className="stat-description">Total</div>
         </div>
         <div className="stat w-full text-center">
           <div className="stat-title">SR</div>
@@ -33,7 +33,7 @@ export default function SRRecordsRiderRacesRow({ row }) {
         <div className="stat w-full text-center">
           <div className="stat-title">Contacts</div>
           <div className="stat-value py-2 text-2xl">{rider.contact}</div>
-          <div className="stat-description">Contact with others</div>
+          <div className="stat-description">Total</div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Closes #

## 🎯 Changes
- add: Expandable rows for BlacklistTables (better ui and designs)
- add Expandable rows for recent race Race Standings table (Rider race stats row)
- add Expandable rows for recent race MMR Analysis table (Rider recent races table row)
- add: Profile tabs tab param usage from when navigating tabs and refreshing
- add: footer plugs to out profiles (thought was cool, idk)